### PR TITLE
feat(chat, core): support batched update history and gzip compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3831,6 +3831,13 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/pako": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.3.tgz",
+            "integrity": "sha512-bq0hMV9opAcrmE0Byyo0fY3Ew4tgOevJmQ9grUhpXQhYfyLJ1Kqg3P33JT5fdbT2AjeAjR51zqqVjAL/HMkx7Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/prop-types": {
             "version": "15.7.13",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
@@ -14146,6 +14153,12 @@
             "dev": true,
             "license": "BlueOak-1.0.0"
         },
+        "node_modules/pako": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+            "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+            "license": "(MIT AND Zlib)"
+        },
         "node_modules/param-case": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
@@ -18088,12 +18101,14 @@
             "version": "0.0.1-beta",
             "dependencies": {
                 "@microsoft/signalr": "^8.0.7",
+                "pako": "^2.1.0",
                 "tweetnacl": "^1.0.3",
                 "tweetnacl-util": "^0.15.1"
             },
             "devDependencies": {
                 "@types/jest": "^30.0.0",
                 "@types/jsdom": "^21.1.7",
+                "@types/pako": "^2.0.3",
                 "jest": "^30.0.2",
                 "jest-environment-jsdom": "^30.0.2",
                 "ts-jest": "^29.4.0",

--- a/packages/whisper-app/src/types/updateType.ts
+++ b/packages/whisper-app/src/types/updateType.ts
@@ -11,4 +11,5 @@ export interface UpdateType {
     delivered?: DeliveredType;
     seen?: SeenType;
     reaction?: ReactionType;
+    history?: UpdateType[];
 }

--- a/packages/whisper-core/package.json
+++ b/packages/whisper-core/package.json
@@ -13,12 +13,14 @@
     },
     "dependencies": {
         "@microsoft/signalr": "^8.0.7",
+        "pako": "^2.1.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
     },
     "devDependencies": {
         "@types/jest": "^30.0.0",
         "@types/jsdom": "^21.1.7",
+        "@types/pako": "^2.0.3",
         "jest": "^30.0.2",
         "jest-environment-jsdom": "^30.0.2",
         "ts-jest": "^29.4.0",


### PR DESCRIPTION
- Added `history?: UpdateType[]` to `UpdateType` to batch cached updates
- Refactored `useChat` hook:
  • Renamed `onMessage` → `onUpdate`
  • Send cached updates as a single `history` payload via `resendCached`
  • Re-emit each historical update in `onUpdate`
- Enhanced `connection-saga`:
  • Imported `gzip`/`ungzip` from `pako`
  • Compress outgoing messages and decompress incoming messages with fallback on decompression errors
- Chore: added `pako` & `@types/pako` to `whisper-core/package.json`
- Updated `package-lock.json` to reflect the new dependencies