### PR TITLE
fix(call-service, signalr-service): enhance error handling and add in…

### DIFF
--- a/packages/whisper-core/__tests__/services/call-service.test.ts
+++ b/packages/whisper-core/__tests__/services/call-service.test.ts
@@ -196,13 +196,11 @@ describe('CallService', () => {
             service.initialize({ serverUrl: 'https://test-server.com', navigator: mockNavigator });
 
             // When & Then
-            await expect(service.update(publicKey)).rejects.toThrow(
-                "[call-service] Failed to send call 'update'.",
-            );
+            await expect(service.update(publicKey)).rejects.toThrow("[call-service] Failed to send call 'update'.");
             expect(mockLogger.warn).toHaveBeenCalledWith(
                 '[call-service] SignalR is not ready. Trying to use http API.',
             );
-            expect((failingApiClient.call as jest.Mock)).toHaveBeenCalled();
+            expect(failingApiClient.call as jest.Mock).toHaveBeenCalled();
             // Ensure the API error was logged from the catch block (string + error)
             expect(mockLogger.error).toHaveBeenCalledWith(
                 expect.stringContaining("[call-service] Error while sending call 'update' via http API."),

--- a/packages/whisper-core/src/services/call-service.ts
+++ b/packages/whisper-core/src/services/call-service.ts
@@ -195,9 +195,7 @@ export function getCallService(
             }
         } else {
             tryApi = true;
-            logger.warn(
-                `[call-service] SignalR is not ready. Trying to use http API.`,
-            );
+            logger.warn(`[call-service] SignalR is not ready. Trying to use http API.`);
         }
 
         if (tryApi) {
@@ -207,10 +205,7 @@ export function getCallService(
             try {
                 response = await apiClient.call(serverUrl, request);
             } catch (error) {
-                logger.error(
-                    `[call-service] Error while sending call '${request.a}' via http API.`,
-                    error,
-                );
+                logger.error(`[call-service] Error while sending call '${request.a}' via http API.`, error);
             }
         }
 

--- a/packages/whisper-core/src/services/session-service.ts
+++ b/packages/whisper-core/src/services/session-service.ts
@@ -12,7 +12,7 @@ export type SessionServiceConfig = {
      * Cryptographic key pair used for signing operations.
      * Essential for verifying the identity of the current user.
      */
-    signingKeyPair: CryptoKeyPair;
+    signingKeyPair?: CryptoKeyPair;
 };
 
 /**

--- a/packages/whisper-core/src/services/worker-service.ts
+++ b/packages/whisper-core/src/services/worker-service.ts
@@ -9,7 +9,7 @@ export type WorkerServiceConfig = {
      * Version identifier for the service worker.
      * Used to trigger service worker updates when the version changes.
      */
-    version: string;
+    version?: string;
 
     /**
      * Optional callback triggered when a new version of the application is available.

--- a/packages/whisper-core/src/whisper.ts
+++ b/packages/whisper-core/src/whisper.ts
@@ -275,6 +275,7 @@ export function getPrototype(logger: Logger): WhisperPrototype {
                 onReady: async () => {
                     await callService.update(sessionService.signingPublicKeyBase64, subscription);
                 },
+                initializationTimeout: 5000,
             });
 
             workerService.controller?.postMessage({ type: 'CLIENT_READY' });


### PR DESCRIPTION
…itialization timeout

- Improved error logging in call-service when SignalR is not ready, ensuring clearer messages.
- Introduced an initialization timeout in signalr-service to prevent indefinite waiting for connection establishment.
- Updated tests to reflect changes in error handling and configuration options.